### PR TITLE
When receiving dm-invite: display user id of inviter if name is missing.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -8543,10 +8543,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     /**
      * Query the user directory with a term matching user IDs, display names and domains.
-     * @param options
-     * @param options.term - the term with which to search.
-     * @param options.limit - the maximum number of results to return. The server will apply a limit if unspecified.
-     * @returns Promise which resolves: an array of results.
+     * @param term - The term with which to search.
+     * @param limit - The maximum number of results to return. The server will apply a limit if unspecified.
+     * @param extraBodyArgs - Additional fields to include in the POST body.
+     * @param extraOptions - Additional request options.
+     * @returns Promise which resolves to an array of results.
      */
     public searchUserDirectory({ term, limit }: { term: string; limit?: number }, extraBodyArgs: {[key: string]: string}|null = {}, extraOptions: IRequestOpts = {}): Promise<IUserDirectoryResponse> {
         const body: Body = {

--- a/src/client.ts
+++ b/src/client.ts
@@ -8548,10 +8548,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param options.limit - the maximum number of results to return. The server will apply a limit if unspecified.
      * @returns Promise which resolves: an array of results.
      */
-    public searchUserDirectory({ term, limit }: { term: string; limit?: number }, extraBodyArgs: {[key:string]: string}|null = {}, extraOptions: IRequestOpts = {}): Promise<IUserDirectoryResponse> {
+    public searchUserDirectory({ term, limit }: { term: string; limit?: number }, extraBodyArgs: {[key: string]: string}|null = {}, extraOptions: IRequestOpts = {}): Promise<IUserDirectoryResponse> {
         const body: Body = {
             search_term: term, 
-            ...extraBodyArgs
+            ...extraBodyArgs,
         };
 
         if (limit !== undefined) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -8549,9 +8549,13 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param extraOptions - Additional request options.
      * @returns Promise which resolves to an array of results.
      */
-    public searchUserDirectory({ term, limit }: { term: string; limit?: number }, extraBodyArgs: {[key: string]: string}|null = {}, extraOptions: IRequestOpts = {}): Promise<IUserDirectoryResponse> {
+    public searchUserDirectory(
+        { term, limit }: { term: string; limit?: number },
+        extraBodyArgs: { [key: string]: string } | null = {},
+        extraOptions: IRequestOpts = {},
+    ): Promise<IUserDirectoryResponse> {
         const body: Body = {
-            search_term: term, 
+            search_term: term,
             ...extraBodyArgs,
         };
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -8543,11 +8543,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     /**
      * Query the user directory with a term matching user IDs, display names and domains.
-     * @param term - The term with which to search.
-     * @param limit - The maximum number of results to return. The server will apply a limit if unspecified.
-     * @param extraBodyArgs - Additional fields to include in the POST body.
+     * @param options - Search options.
+     * @param options.term - The term with which to search.
+     * @param options.limit - Maximum number of results to return.
+     * @param extraBodyArgs - Additional POST body fields.
      * @param extraOptions - Additional request options.
-     * @returns Promise which resolves to an array of results.
+     * @returns Promise resolving to an array of results.
      */
     public searchUserDirectory(
         { term, limit }: { term: string; limit?: number },

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -3408,8 +3408,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
             // Check if this room is a DM by looking in account data
             const mDirectEvent = this.client.getAccountData("m.direct");
             const mDirectContent = mDirectEvent?.getContent() ?? {};
-          // Get Display Names room 
-            // 
+            // Get Display Names room
+            //
             // Check if this roomId exists in any of the DM arrays
             const isDmRoom = Object.values(mDirectContent).some((roomIds: any) => {
                 return Array.isArray(roomIds) && roomIds.includes(this.roomId);
@@ -3423,9 +3423,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
                     if (inviterUserId) {
                         // Try to get display name from room member, fall back to user ID
                         const inviterMember = this.getMember(inviterUserId);
-                        const inviterName = inviterMember?.name && inviterMember.name.trim()
-                            ? inviterMember.name
-                            : inviterUserId;
+                        const inviterName =
+                            inviterMember?.name && inviterMember.name.trim() ? inviterMember.name : inviterUserId;
 
                         return this.roomNameGenerator({
                             type: RoomNameType.Generated,
@@ -3436,7 +3435,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
                 }
             }
         }
-        // END VERJI:special handling for DM invitations 
+        // END VERJI:special handling for DM invitations
 
         const joinedMemberCount = this.currentState.getJoinedMemberCount();
         const invitedMemberCount = this.currentState.getInvitedMemberCount();

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -3402,6 +3402,42 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
             });
         }
 
+        // VERJI: Special handling for DM invite rooms - show the inviter's name
+        // This ensures that when you're invited to a DM, you see who invited you instead of "Empty room"
+        if (this.getMyMembership() === KnownMembership.Invite) {
+            // Check if this room is a DM by looking in account data
+            const mDirectEvent = this.client.getAccountData("m.direct");
+            const mDirectContent = mDirectEvent?.getContent() ?? {};
+          // Get Display Names room 
+            // 
+            // Check if this roomId exists in any of the DM arrays
+            const isDmRoom = Object.values(mDirectContent).some((roomIds: any) => {
+                return Array.isArray(roomIds) && roomIds.includes(this.roomId);
+            });
+
+            // Only show inviter name for DM rooms
+            if (isDmRoom) {
+                const myMember = this.getMember(userId);
+                if (myMember) {
+                    const inviterUserId = myMember.events.member?.getSender();
+                    if (inviterUserId) {
+                        // Try to get display name from room member, fall back to user ID
+                        const inviterMember = this.getMember(inviterUserId);
+                        const inviterName = inviterMember?.name && inviterMember.name.trim()
+                            ? inviterMember.name
+                            : inviterUserId;
+
+                        return this.roomNameGenerator({
+                            type: RoomNameType.Generated,
+                            names: [inviterName],
+                            count: 1,
+                        });
+                    }
+                }
+            }
+        }
+        // END VERJI:special handling for DM invitations 
+
         const joinedMemberCount = this.currentState.getJoinedMemberCount();
         const invitedMemberCount = this.currentState.getInvitedMemberCount();
         // -1 because these numbers include the syncing user


### PR DESCRIPTION
* Added a fallback to "userId" if member.name not available for any reason -when inviting new users
