### PR TITLE
Automatic keybackup re-signing

### DIFF
--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -207,7 +207,7 @@ export class EncryptionSetupOperation {
                 // be trusted via cross-signing.
                 logger.log(
                     `[VERJI.BACKUP.RESIGN] Uploading re-signed backup metadata to server ` +
-                    `(version ${this.keyBackupInfo.version})...`
+                        `(version ${this.keyBackupInfo.version})...`,
                 );
 
                 await baseApis.http.authedRequest(
@@ -223,7 +223,7 @@ export class EncryptionSetupOperation {
 
                 logger.log(
                     `[VERJI.BACKUP.RESIGN] Successfully uploaded re-signed backup v${this.keyBackupInfo.version}. ` +
-                    `Backup now has cross-signing signature and should become usable.`
+                        `Backup now has cross-signing signature and should become usable.`,
                 );
             } else {
                 // add new key backup
@@ -232,15 +232,13 @@ export class EncryptionSetupOperation {
                 });
             }
             // tell the backup manager to re-check the keys now that they have been (maybe) updated
-            logger.log(
-                `[VERJI.BACKUP.RESIGN] Triggering backup verification to check if backup is now usable...`
-            );
+            logger.log(`[VERJI.BACKUP.RESIGN] Triggering backup verification to check if backup is now usable...`);
             const checkResult = await crypto.backupManager.checkKeyBackup();
 
             if (checkResult) {
                 logger.log(
                     `[VERJI.BACKUP.RESIGN] Backup verification complete. ` +
-                    `Backup v${checkResult.backupInfo?.version} is now ${checkResult.trustInfo?.usable ? 'USABLE ✓' : 'NOT USABLE ✗'}`
+                        `Backup v${checkResult.backupInfo?.version} is now ${checkResult.trustInfo?.usable ? "USABLE ✓" : "NOT USABLE ✗"}`,
                 );
             }
         }

--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -205,6 +205,11 @@ export class EncryptionSetupOperation {
                 // The backup is trusted because the user provided the private key.
                 // Sign the backup with the cross signing key so the key backup can
                 // be trusted via cross-signing.
+                logger.log(
+                    `[VERJI.BACKUP.RESIGN] Uploading re-signed backup metadata to server ` +
+                    `(version ${this.keyBackupInfo.version})...`
+                );
+
                 await baseApis.http.authedRequest(
                     Method.Put,
                     "/room_keys/version/" + this.keyBackupInfo.version,
@@ -215,6 +220,11 @@ export class EncryptionSetupOperation {
                     },
                     { prefix: ClientPrefix.V3 },
                 );
+
+                logger.log(
+                    `[VERJI.BACKUP.RESIGN] Successfully uploaded re-signed backup v${this.keyBackupInfo.version}. ` +
+                    `Backup now has cross-signing signature and should become usable.`
+                );
             } else {
                 // add new key backup
                 await baseApis.http.authedRequest(Method.Post, "/room_keys/version", undefined, this.keyBackupInfo, {
@@ -222,7 +232,17 @@ export class EncryptionSetupOperation {
                 });
             }
             // tell the backup manager to re-check the keys now that they have been (maybe) updated
-            await crypto.backupManager.checkKeyBackup();
+            logger.log(
+                `[VERJI.BACKUP.RESIGN] Triggering backup verification to check if backup is now usable...`
+            );
+            const checkResult = await crypto.backupManager.checkKeyBackup();
+
+            if (checkResult) {
+                logger.log(
+                    `[VERJI.BACKUP.RESIGN] Backup verification complete. ` +
+                    `Backup v${checkResult.backupInfo?.version} is now ${checkResult.trustInfo?.usable ? 'USABLE ✓' : 'NOT USABLE ✗'}`
+                );
+            }
         }
     }
 }

--- a/src/crypto/backup.ts
+++ b/src/crypto/backup.ts
@@ -284,6 +284,57 @@ export class BackupManager {
 
         const trustInfo = await this.isKeyBackupTrusted(backupInfo);
 
+        // Automatic re-signing: If backup is not usable but we have cross-signing, try to fix it
+        if (!trustInfo.usable && backupInfo && this.baseApis.crypto!.crossSigningInfo.getId()) {
+            logger.log(
+                `[VERJI.BACKUP.RESIGN] Backup v${backupInfo.version} is not usable ` +
+                `(trusted_locally: ${trustInfo.trusted_locally}). Attempting automatic re-signing with cross-signing master key.`
+            );
+
+            try {
+                // Sign the backup auth_data with cross-signing master key
+                await this.baseApis.crypto!.crossSigningInfo.signObject(backupInfo.auth_data, "master");
+
+                // Upload the re-signed metadata to server
+                await this.baseApis.http.authedRequest(
+                    Method.Put,
+                    `/room_keys/version/${backupInfo.version}`,
+                    undefined,
+                    {
+                        algorithm: backupInfo.algorithm,
+                        auth_data: backupInfo.auth_data,
+                    },
+                    { prefix: ClientPrefix.V3 },
+                );
+
+                logger.log(
+                    `[VERJI.BACKUP.RESIGN] Successfully re-signed and uploaded backup v${backupInfo.version}. ` +
+                    `Re-checking trust status...`
+                );
+
+                // Re-check trust after re-signing (update trustInfo for the logic below)
+                const updatedTrustInfo = await this.isKeyBackupTrusted(backupInfo);
+                if (updatedTrustInfo.usable) {
+                    logger.log(
+                        `[VERJI.BACKUP.RESIGN] Backup v${backupInfo.version} is now USABLE ✓ after re-signing.`
+                    );
+                    // Update trustInfo so the enable logic below works
+                    Object.assign(trustInfo, updatedTrustInfo);
+                } else {
+                    logger.warn(
+                        `[VERJI.BACKUP.RESIGN] Backup v${backupInfo.version} is still not usable after re-signing. ` +
+                        `This is unexpected.`
+                    );
+                }
+            } catch (error) {
+                logger.error(
+                    `[VERJI.BACKUP.RESIGN] Failed to automatically re-sign backup v${backupInfo.version}:`,
+                    error
+                );
+                // Continue with original trustInfo - will follow normal enable/disable logic
+            }
+        }
+
         if (trustInfo.usable && !this.backupInfo) {
             logger.log(`Found usable key backup v${backupInfo!.version}: enabling key backups`);
             await this.enableKeyBackup(backupInfo!);

--- a/src/crypto/backup.ts
+++ b/src/crypto/backup.ts
@@ -288,7 +288,7 @@ export class BackupManager {
         if (!trustInfo.usable && backupInfo && this.baseApis.crypto!.crossSigningInfo.getId()) {
             logger.log(
                 `[VERJI.BACKUP.RESIGN] Backup v${backupInfo.version} is not usable ` +
-                `(trusted_locally: ${trustInfo.trusted_locally}). Attempting automatic re-signing with cross-signing master key.`
+                    `(trusted_locally: ${trustInfo.trusted_locally}). Attempting automatic re-signing with cross-signing master key.`,
             );
 
             try {
@@ -309,27 +309,25 @@ export class BackupManager {
 
                 logger.log(
                     `[VERJI.BACKUP.RESIGN] Successfully re-signed and uploaded backup v${backupInfo.version}. ` +
-                    `Re-checking trust status...`
+                        `Re-checking trust status...`,
                 );
 
                 // Re-check trust after re-signing (update trustInfo for the logic below)
                 const updatedTrustInfo = await this.isKeyBackupTrusted(backupInfo);
                 if (updatedTrustInfo.usable) {
-                    logger.log(
-                        `[VERJI.BACKUP.RESIGN] Backup v${backupInfo.version} is now USABLE ✓ after re-signing.`
-                    );
+                    logger.log(`[VERJI.BACKUP.RESIGN] Backup v${backupInfo.version} is now USABLE ✓ after re-signing.`);
                     // Update trustInfo so the enable logic below works
                     Object.assign(trustInfo, updatedTrustInfo);
                 } else {
                     logger.warn(
                         `[VERJI.BACKUP.RESIGN] Backup v${backupInfo.version} is still not usable after re-signing. ` +
-                        `This is unexpected.`
+                            `This is unexpected.`,
                     );
                 }
             } catch (error) {
                 logger.error(
                     `[VERJI.BACKUP.RESIGN] Failed to automatically re-sign backup v${backupInfo.version}:`,
-                    error
+                    error,
                 );
                 // Continue with original trustInfo - will follow normal enable/disable logic
             }

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -865,12 +865,6 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
             const device = this.deviceList.getStoredDevice(this.userId, this.deviceId)!;
             const deviceSignature = await crossSigningInfo.signDevice(this.userId, device);
             builder.addKeySignature(this.userId, this.deviceId, deviceSignature!);
-
-            // Sign message key backup with cross-signing master key
-            if (this.backupManager.backupInfo) {
-                await crossSigningInfo.signObject(this.backupManager.backupInfo.auth_data, "master");
-                builder.addSessionBackup(this.backupManager.backupInfo);
-            }
         };
 
         const publicKeysOnDevice = this.crossSigningInfo.getId();
@@ -906,6 +900,33 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
             await this.checkOwnCrossSigningTrust({
                 allowPrivateKeyRequests: true,
             });
+        }
+
+        // Sign message key backup with cross-signing master key (if backup exists and is not usable)
+        // This runs for ALL bootstrap paths to ensure broken backups get fixed
+        if (this.backupManager.backupInfo && crossSigningInfo.getId()) {
+            const backupVersion = this.backupManager.backupInfo.version;
+            const trustInfo = await this.backupManager.isKeyBackupTrusted(this.backupManager.backupInfo);
+
+            // Only re-sign if backup is not currently usable (missing/invalid cross-signing signature)
+            if (!trustInfo.usable) {
+                logger.log(
+                    `[VERJI.BACKUP.RESIGN] Detected existing key backup v${backupVersion} that is NOT usable ` +
+                    `(trusted_locally: ${trustInfo.trusted_locally}). Re-signing with cross-signing master key.`
+                );
+
+                await crossSigningInfo.signObject(this.backupManager.backupInfo.auth_data, "master");
+                builder.addSessionBackup(this.backupManager.backupInfo);
+
+                logger.log(
+                    `[VERJI.BACKUP.RESIGN] Successfully signed backup v${backupVersion} with cross-signing key. ` +
+                    `Signature will be uploaded to server. Backup should become usable.`
+                );
+            } else {
+                logger.log(
+                    `[VERJI.BACKUP.RESIGN] Backup v${backupVersion} is already usable. Skipping re-signing.`
+                );
+            }
         }
 
         // Assuming no app-supplied callback, default to storing new private keys in

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -912,7 +912,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
             if (!trustInfo.usable) {
                 logger.log(
                     `[VERJI.BACKUP.RESIGN] Detected existing key backup v${backupVersion} that is NOT usable ` +
-                    `(trusted_locally: ${trustInfo.trusted_locally}). Re-signing with cross-signing master key.`
+                        `(trusted_locally: ${trustInfo.trusted_locally}). Re-signing with cross-signing master key.`,
                 );
 
                 await crossSigningInfo.signObject(this.backupManager.backupInfo.auth_data, "master");
@@ -920,12 +920,10 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
 
                 logger.log(
                     `[VERJI.BACKUP.RESIGN] Successfully signed backup v${backupVersion} with cross-signing key. ` +
-                    `Signature will be uploaded to server. Backup should become usable.`
+                        `Signature will be uploaded to server. Backup should become usable.`,
                 );
             } else {
-                logger.log(
-                    `[VERJI.BACKUP.RESIGN] Backup v${backupVersion} is already usable. Skipping re-signing.`
-                );
+                logger.log(`[VERJI.BACKUP.RESIGN] Backup v${backupVersion} is already usable. Skipping re-signing.`);
             }
         }
 


### PR DESCRIPTION
One of the options suggested in:
- [Latest UTD investigation: Unverified Key Backup hypothesis and how to locate users with this issue](https://github.com/orgs/verji/discussions/170)

In this PR:
- We have implemented an automatic resigning of the keybackup, if it is locally trusted, and doesn't have a valid signature
  - This "fixes" the keybackup as it is signed with the masterkey, and will now always be trusted
  - Tested on users who had the bug where the keybackup was signed with a now missing device, and had no way to verify it.
    - With automatic resign, the keybackup will now be trusted and backup keys like it is supposed to

Details:
1. backup.ts - Two Key Changes
- Change 1: Enable Locally-Trusted Backups
- Change 2: Automatic Re-signing
  - Self healing users with this issue, to make sure it is completely trusted later. 

2. crypto/index.ts - Re-signing During Bootstrap
- An attempt to fix the issue, as early as possible (during bootstrap)

3. EncryptionSetup.ts - Enhanced Logging
- Added logging when backup has be resigned
- Logs if backup is successfully verified